### PR TITLE
:package: chore: add Flyway dependency and configure Spring Boot integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,15 @@
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
         <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,10 @@ spring.datasource.password=${POSTGRES_PASSWORD:pizzaDeBatata}
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.hibernate.ddl-auto=update
 
+# Flyway migration configuration
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+
 # Configuration for security JsonWebToken
 security.jwt.encryption_key=${JWT_SECRET:rN59JmShwttGkMNX5soAEStN8r9A+M1OZx38gP4kn2MVaX0w9uCZTLP5n70yQ60Kcu7dnqkZk6a8chPXoJfuhA==}
 security.jwt.expiration_time=${JWT_EXPIRATION:3600000}

--- a/src/test/java/com/christmas/dessert/voting/christmas_dessert_voting/ModulithVerificationTest.java
+++ b/src/test/java/com/christmas/dessert/voting/christmas_dessert_voting/ModulithVerificationTest.java
@@ -1,0 +1,13 @@
+package com.christmas.dessert.voting.christmas_dessert_voting;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.modulith.core.ApplicationModules;
+
+class ModulithVerificationTest {
+
+    @Test
+    void verifyModulith() {
+        var modules = ApplicationModules.of(ChristmasDessertVotingApplication.class);
+        modules.verify();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `flyway-core` and `flyway-database-postgresql` dependencies to `pom.xml`
- Configure Flyway in `application.properties` (enabled, classpath location)
- Create empty `db/migration/` directory for future migration scripts
- Create `ModulithVerificationTest` to validate Spring Modulith module boundaries

## Verification
- 47/47 existing tests passing
- Modulith verification test passes (architecture is clean)
- All unit tests without application context (no PostgreSQL needed for tests)

Closes #32