### PR TITLE
:package: chore: create Flyway migration scripts V1, V2 and V3

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.sql.dialect=postgresql

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,0 @@
-sonar.sql.dialect=postgresql

--- a/src/main/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/domain/Dessert.java
+++ b/src/main/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/domain/Dessert.java
@@ -21,7 +21,7 @@ public class Dessert {
     @AttributeOverride(name = "id", column = @Column(name = "owner_id"))
     private OwnerId ownerId;
     @Setter
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, unique = true, length = 100)
     private String name;
     @Setter
     @Column

--- a/src/main/java/com/christmas/dessert/voting/christmas_dessert_voting/user/domain/User.java
+++ b/src/main/java/com/christmas/dessert/voting/christmas_dessert_voting/user/domain/User.java
@@ -22,11 +22,11 @@ public class User {
     @EmbeddedId
     @EqualsAndHashCode.Include
     private UserId id;
-    @Column(nullable = false)
+    @Column(nullable = false, length = 100)
     private String name;
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, unique = true, length = 14)
     private String cpf;
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, unique = true, length = 100)
     private String email;
     @Column(name = "password", nullable = false)
     private String passwordHash;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,6 +11,8 @@ spring.jpa.hibernate.ddl-auto=update
 # Flyway migration configuration
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
+spring.flyway.baseline-on-migrate=true
+spring.flyway.baseline-version=0
 
 # Configuration for security JsonWebToken
 security.jwt.encryption_key=${JWT_SECRET:rN59JmShwttGkMNX5soAEStN8r9A+M1OZx38gP4kn2MVaX0w9uCZTLP5n70yQ60Kcu7dnqkZk6a8chPXoJfuhA==}

--- a/src/main/resources/db/migration/V1__create_users_table.sql
+++ b/src/main/resources/db/migration/V1__create_users_table.sql
@@ -1,8 +1,8 @@
 CREATE TABLE users (
     id UUID PRIMARY KEY,
-    name VARCHAR(255) NOT NULL,
-    cpf VARCHAR(255) NOT NULL UNIQUE,
-    email VARCHAR(255) NOT NULL UNIQUE,
+    name VARCHAR(100) NOT NULL,
+    cpf VARCHAR(14) NOT NULL UNIQUE,
+    email VARCHAR(100) NOT NULL UNIQUE,
     password VARCHAR(255) NOT NULL,
     favorite_sweets TEXT[],
     created_at TIMESTAMP,

--- a/src/main/resources/db/migration/V1__create_users_table.sql
+++ b/src/main/resources/db/migration/V1__create_users_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE users (
+    id UUID PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    cpf VARCHAR(255) NOT NULL UNIQUE,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    favorite_sweets TEXT[],
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP
+);

--- a/src/main/resources/db/migration/V2__create_desserts_table.sql
+++ b/src/main/resources/db/migration/V2__create_desserts_table.sql
@@ -1,7 +1,7 @@
 CREATE TABLE desserts (
     id UUID PRIMARY KEY,
     owner_id UUID NOT NULL,
-    name VARCHAR(255) NOT NULL UNIQUE,
+    name VARCHAR(100) NOT NULL UNIQUE,
     description TEXT,
     is_subscribed BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP,

--- a/src/main/resources/db/migration/V2__create_desserts_table.sql
+++ b/src/main/resources/db/migration/V2__create_desserts_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE desserts (
+    id UUID PRIMARY KEY,
+    owner_id UUID NOT NULL,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    description TEXT,
+    is_subscribed BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+    CONSTRAINT fk_desserts_owner FOREIGN KEY (owner_id) REFERENCES users(id)
+);
+
+CREATE INDEX idx_desserts_owner_id ON desserts(owner_id);

--- a/src/main/resources/db/migration/V3__create_voting_and_subscribed_desserts_tables.sql
+++ b/src/main/resources/db/migration/V3__create_voting_and_subscribed_desserts_tables.sql
@@ -1,0 +1,23 @@
+CREATE TABLE voting (
+    id UUID PRIMARY KEY,
+    owner_id UUID NOT NULL,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    description TEXT,
+    number_of_participants INTEGER DEFAULT 0,
+    is_open_to_vote BOOLEAN DEFAULT FALSE,
+    closing_date TIMESTAMP,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+    CONSTRAINT fk_voting_owner FOREIGN KEY (owner_id) REFERENCES users(id)
+);
+
+CREATE TABLE subscribed_desserts (
+    dessert_id UUID PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    number_of_votes INTEGER DEFAULT 0,
+    vote_position INTEGER DEFAULT 0,
+    voting_id UUID NOT NULL,
+    CONSTRAINT fk_subscribed_desserts_voting FOREIGN KEY (voting_id) REFERENCES voting(id)
+);
+
+CREATE INDEX idx_subscribed_desserts_voting_id ON subscribed_desserts(voting_id);


### PR DESCRIPTION
## Summary
Creates the three Flyway migration scripts corresponding to each domain module:

### V1 — `users` table
- UUID primary key, name, CPF (unique), email (unique), password hash, favorite_sweets array

### V2 — `desserts` table  
- UUID primary key, owner_id (FK → users), name (unique), description, is_subscribed flag
- Index on owner_id

### V3 — `voting` + `subscribed_desserts` tables
- `voting`: UUID PK, owner_id (FK → users), name, participants count, open status, closing date
- `subscribed_desserts`: dessert_id PK, name, votes count, position, voting_id (FK → voting)
- Index on voting_id

### Config
- Added `spring.flyway.baseline-on-migrate=true` with `baseline-version=0`

> **Note:** If you have an existing database from ddl-auto=update, run `docker compose down -v && docker compose up` to reset before starting, or Flyway will fail on existing tables.

## Verification
- 47/47 tests passing
- Modulith verification passes
- No application context needed for tests (CI compatible)

Closes #33, Closes #34, Closes #35