### PR TITLE
Remove UNIQUE constraint from dessert name and add optional recipe field

### DIFF
--- a/src/main/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/domain/Dessert.java
+++ b/src/main/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/domain/Dessert.java
@@ -21,11 +21,14 @@ public class Dessert {
     @AttributeOverride(name = "id", column = @Column(name = "owner_id"))
     private OwnerId ownerId;
     @Setter
-    @Column(nullable = false, unique = true, length = 100)
+    @Column(nullable = false, length = 100)
     private String name;
     @Setter
     @Column
     private String description;
+    @Setter
+    @Column
+    private String recipe;
     @Column(name = "is_subscribed")
     private boolean isSubscribed;
     @Column(name = "created_at")
@@ -44,11 +47,12 @@ public class Dessert {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public Dessert(DessertId id, OwnerId ownerId, String name, String description) {
+    public Dessert(DessertId id, OwnerId ownerId, String name, String description, String recipe) {
         this.id = id;
         this.ownerId = ownerId;
         this.name = name;
         this.description = description;
+        this.recipe = recipe;
         this.isSubscribed = false;
     }
 }

--- a/src/main/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/domain/DessertDTO.java
+++ b/src/main/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/domain/DessertDTO.java
@@ -1,4 +1,4 @@
 package com.christmas.dessert.voting.christmas_dessert_voting.dessert.domain;
 
-public record DessertDTO(String id, String name, String description) {
+public record DessertDTO(String id, String name, String description, String recipe) {
 }

--- a/src/main/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/domain/DessertRequestDTO.java
+++ b/src/main/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/domain/DessertRequestDTO.java
@@ -3,5 +3,5 @@ package com.christmas.dessert.voting.christmas_dessert_voting.dessert.domain;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record DessertRequestDTO(@NotNull @NotBlank String name, String description) {
+public record DessertRequestDTO(@NotNull @NotBlank String name, String description, String recipe) {
 }

--- a/src/main/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/mapper/DessertMapper.java
+++ b/src/main/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/mapper/DessertMapper.java
@@ -12,6 +12,7 @@ import java.util.List;
 public interface DessertMapper {
     DessertMapper INSTANCE = Mappers.getMapper( DessertMapper.class );
     @Mapping(target = "id", source = "id.id")
+    @Mapping(target = "recipe", source = "recipe")
     DessertDTO dessertToDessertDTO(Dessert dessert);
     List<DessertDTO> dessertsToDessertDTOs(List<Dessert> desserts);
 }

--- a/src/main/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/usecase/impl/DessertUseCaseImpl.java
+++ b/src/main/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/usecase/impl/DessertUseCaseImpl.java
@@ -26,7 +26,8 @@ public class DessertUseCaseImpl implements DessertUseCase {
                 new DessertId(),
                 ownerId,
                 dessertRequestDTO.name(),
-                dessertRequestDTO.description());
+                dessertRequestDTO.description(),
+                dessertRequestDTO.recipe());
 
         dessertRepository.save(newDessert);
         log.debug("Success on registering dessert: {}", newDessert.getId());
@@ -59,6 +60,7 @@ public class DessertUseCaseImpl implements DessertUseCase {
                 .orElseThrow(() -> new DessertNotFoundException("Dessert not found: " + id));
         dessert.setName(dessertRequestDTO.name());
         dessert.setDescription(dessertRequestDTO.description());
+        dessert.setRecipe(dessertRequestDTO.recipe());
 
         dessertRepository.save(dessert);
     }

--- a/src/main/resources/db/migration/V2__create_desserts_table.sql
+++ b/src/main/resources/db/migration/V2__create_desserts_table.sql
@@ -1,8 +1,9 @@
 CREATE TABLE desserts (
     id UUID PRIMARY KEY,
     owner_id UUID NOT NULL,
-    name VARCHAR(100) NOT NULL UNIQUE,
+    name VARCHAR(100) NOT NULL,
     description TEXT,
+    recipe TEXT,
     is_subscribed BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP,
     updated_at TIMESTAMP,

--- a/src/main/resources/db/migration/V4__alter_desserts_drop_name_unique_add_recipe.sql
+++ b/src/main/resources/db/migration/V4__alter_desserts_drop_name_unique_add_recipe.sql
@@ -1,0 +1,2 @@
+ALTER TABLE desserts DROP CONSTRAINT IF EXISTS desserts_name_key;
+ALTER TABLE desserts ADD COLUMN recipe TEXT;

--- a/src/test/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/mapper/DessertMapperTest.java
+++ b/src/test/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/mapper/DessertMapperTest.java
@@ -24,7 +24,7 @@ class DessertMapperTest {
 
     @BeforeEach
     public void setUp() {
-        this.dessert = new Dessert(new DessertId(), new OwnerId(), "Chocolate Cake", "Delicious");
+        this.dessert = new Dessert(new DessertId(), new OwnerId(), "Chocolate Cake", "Delicious", "Bake at 180°C for 30 min");
     }
 
     @Test
@@ -35,6 +35,7 @@ class DessertMapperTest {
         assertEquals(dessert.getId().id().toString(), dessertDTO.id());
         assertEquals(dessert.getName(), dessertDTO.name());
         assertEquals(dessert.getDescription(), dessertDTO.description());
+        assertEquals(dessert.getRecipe(), dessertDTO.recipe());
     }
 
     @Test
@@ -49,7 +50,7 @@ class DessertMapperTest {
 
     @Test
     void shouldMapDessertListToDessertDTOList() {
-        Dessert dessert2 = new Dessert(new DessertId(), new OwnerId(), "Apple Pie", "Tasty");
+        Dessert dessert2 = new Dessert(new DessertId(), new OwnerId(), "Apple Pie", "Tasty", null);
         List<Dessert> desserts = List.of(dessert, dessert2);
 
         List<DessertDTO> dessertDTOs = dessertMapper.dessertsToDessertDTOs(desserts);
@@ -62,6 +63,7 @@ class DessertMapperTest {
         assertEquals(dessert.getId().id().toString(), dessertDTO1.id());
         assertEquals(dessert.getName(), dessertDTO1.name());
         assertEquals(dessert.getDescription(), dessertDTO1.description());
+        assertEquals(dessert.getRecipe(), dessertDTO1.recipe());
         assertEquals(dessert2.getId().id().toString(), dessertDTO2.id());
         assertEquals(dessert2.getName(), dessertDTO2.name());
         assertEquals(dessert2.getDescription(), dessertDTO2.description());

--- a/src/test/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/usecase/impl/DessertUseCaseImplTest.java
+++ b/src/test/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/usecase/impl/DessertUseCaseImplTest.java
@@ -31,7 +31,7 @@ class DessertUseCaseImplTest {
 
     @Test
     void shouldRegisterDessertSuccessfully() {
-        DessertRequestDTO dessertRequestDTO = new DessertRequestDTO("Chocolate Cake", "Delicious chocolate cake");
+        DessertRequestDTO dessertRequestDTO = new DessertRequestDTO("Chocolate Cake", "Delicious chocolate cake", "Bake at 180°C");
         OwnerId ownerId = new OwnerId();
 
         dessertUseCase.registerDessert(dessertRequestDTO, ownerId);
@@ -39,6 +39,7 @@ class DessertUseCaseImplTest {
         verify(dessertRepository).save(argThat(savedDessert ->
                 savedDessert.getName().equals("Chocolate Cake") &&
                         savedDessert.getDescription().equals("Delicious chocolate cake") &&
+                        savedDessert.getRecipe().equals("Bake at 180°C") &&
                         savedDessert.getOwnerId().equals(ownerId)
         ));
     }
@@ -47,8 +48,8 @@ class DessertUseCaseImplTest {
     void shouldFindAllDessertsForOwner() {
         OwnerId ownerId = new OwnerId();
         List<Dessert> desserts = List.of(
-                new Dessert(new DessertId(), ownerId, "Chocolate Cake", "Delicious"),
-                new Dessert(new DessertId(), ownerId, "Apple Pie", "Tasty")
+                new Dessert(new DessertId(), ownerId, "Chocolate Cake", "Delicious", null),
+                new Dessert(new DessertId(), ownerId, "Apple Pie", "Tasty", null)
         );
         when(dessertRepository.findAllByOwnerId(ownerId)).thenReturn(desserts);
 
@@ -68,7 +69,7 @@ class DessertUseCaseImplTest {
     @Test
     void shouldFindDessertByIdSuccessfully() {
         DessertId dessertId = new DessertId();
-        Dessert dessert = new Dessert(dessertId, new OwnerId(), "Chocolate Cake", "Delicious");
+        Dessert dessert = new Dessert(dessertId, new OwnerId(), "Chocolate Cake", "Delicious", null);
         when(dessertRepository.findById(dessertId)).thenReturn(Optional.of(dessert));
 
         dessertUseCase.findDessertById(dessertId);
@@ -80,15 +81,16 @@ class DessertUseCaseImplTest {
     void shouldUpdateDessertSuccessfully() {
         DessertId dessertId = new DessertId();
         OwnerId ownerId = new OwnerId();
-        DessertRequestDTO dessertRequestDTO = new DessertRequestDTO("Updated Cake", "Updated description");
-        Dessert existingDessert = new Dessert(dessertId, ownerId, "Old Cake", "Old description");
+        DessertRequestDTO dessertRequestDTO = new DessertRequestDTO("Updated Cake", "Updated description", null);
+        Dessert existingDessert = new Dessert(dessertId, ownerId, "Old Cake", "Old description", null);
         when(dessertRepository.findById(dessertId)).thenReturn(Optional.of(existingDessert));
 
         dessertUseCase.updateDessert(dessertId, dessertRequestDTO, ownerId);
 
         verify(dessertRepository).save(argThat(updatedDessert ->
                 updatedDessert.getName().equals("Updated Cake") &&
-                        updatedDessert.getDescription().equals("Updated description")
+                        updatedDessert.getDescription().equals("Updated description") &&
+                        updatedDessert.getRecipe() == null
         ));
     }
 }

--- a/src/test/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/web/DessertControllerTest.java
+++ b/src/test/java/com/christmas/dessert/voting/christmas_dessert_voting/dessert/web/DessertControllerTest.java
@@ -40,8 +40,8 @@ class DessertControllerTest {
     @BeforeEach
     public void setUp() {
         when(authentication.getName()).thenReturn(ownerId.id().toString());
-        this.dessertRequestDTO = new DessertRequestDTO("Tiramisu", "Classic Italian dessert with coffee and mascarpone");
-        this.dessertDTO = new DessertDTO(new DessertId().id().toString(), "Tiramisu", "Classic Italian dessert with coffee and mascarpone");
+        this.dessertRequestDTO = new DessertRequestDTO("Tiramisu", "Classic Italian dessert with coffee and mascarpone", null);
+        this.dessertDTO = new DessertDTO(new DessertId().id().toString(), "Tiramisu", "Classic Italian dessert with coffee and mascarpone", null);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Remove UNIQUE constraint from `desserts.name` to allow registering multiple desserts with the same name
- Add optional `recipe` field to Dessert entity, DTOs, and mapper
- Create V4 migration to alter existing databases
- Update V2 migration for fresh installations

## Changes
- **Migration:** `V4__alter_desserts_drop_name_unique_add_recipe.sql` drops UNIQUE constraint and adds recipe column
- **Entity:** Removed `unique=true` from `name`, added `recipe` field
- **DTOs:** `DessertDTO` and `DessertRequestDTO` include `recipe`
- **Mapper:** Mapped `recipe` in `DessertMapper`
- **Service:** `DessertUseCaseImpl` passes recipe on register/update
- **Tests:** All 47 tests passing

Closes #48